### PR TITLE
Updating fastestGame statistic so it updates 

### DIFF
--- a/src/app/services/userActiveGamesBFF.service.ts
+++ b/src/app/services/userActiveGamesBFF.service.ts
@@ -282,7 +282,7 @@ async function endGameService(puzzle, req) {
             });
     } else {
 
-        const bodyData = [{
+        const bodyData = {
             "userID": parseUserID(token.sub.toString()),
             "dateRange": "1111-11-11",
             "score": score + totalStatsResponseBody[0].score,
@@ -293,7 +293,7 @@ async function endGameService(puzzle, req) {
             "numHintsUsed": activeGameResponseBody[0].numHintsUsed + totalStatsResponseBody[0].numHintsUsed,
             "numWrongCellsPlayed": activeGameResponseBody[0].numWrongCellsPlayed + totalStatsResponseBody[0].numWrongCellsPlayed,
             "numGamesPlayed": 1 + totalStatsResponseBody[0].numGamesPlayed
-        }];
+        };
 
         await axios.patch(baseUserGameStatisticsUrl + "?userID=" + parseUserID(token.sub.toString()) + "&dateRange=1111-11-11", bodyData, {
             headers: {
@@ -354,8 +354,6 @@ async function endGameService(puzzle, req) {
             "numWrongCellsPlayed": activeGameResponseBody[0].numWrongCellsPlayed,
             "numGamesPlayed": 1
         }];
-
-        console.log(bodyData);
 
         await axios.post(baseUserGameStatisticsUrl, bodyData, {
             headers: {

--- a/src/app/services/userActiveGamesBFF.service.ts
+++ b/src/app/services/userActiveGamesBFF.service.ts
@@ -287,8 +287,8 @@ async function endGameService(puzzle, req) {
             "dateRange": "1111-11-11",
             "score": score + totalStatsResponseBody[0].score,
             "averageSolveTime": (activeGameResponseBody[0].currentTime + totalStatsResponseBody[0].totalSolveTime) / (1 + totalStatsResponseBody[0].numGamesPlayed),
-            "fastestSolveTime": (activeGameResponseBody[0].currentTime < totalStatsResponseBody[0].fastestSolveTime)
-                ? activeGameResponseBody[0].currentTime : totalStatsResponseBody[0].fastestSolveTime,
+            "fastestSolveTime": (activeGameResponseBody[0].currentTime > totalStatsResponseBody[0].fastestSolveTime && totalStatsResponseBody[0].fastestSolveTime != 0)
+                ? totalStatsResponseBody[0].fastestSolveTime : activeGameResponseBody[0].currentTime,
             "totalSolveTime": activeGameResponseBody[0].currentTime + totalStatsResponseBody[0].totalSolveTime,
             "numHintsUsed": activeGameResponseBody[0].numHintsUsed + totalStatsResponseBody[0].numHintsUsed,
             "numWrongCellsPlayed": activeGameResponseBody[0].numWrongCellsPlayed + totalStatsResponseBody[0].numWrongCellsPlayed,
@@ -378,7 +378,8 @@ async function endGameService(puzzle, req) {
             "dateRange": currentDate,
             "score": score + dailyStatsResponseBody[0].score,
             "averageSolveTime": (activeGameResponseBody[0].currentTime + dailyStatsResponseBody[0].totalSolveTime) / (1 + dailyStatsResponseBody[0].numGamesPlayed),
-            "fastestSolveTime": (activeGameResponseBody[0].currentTime < dailyStatsResponseBody[0].fastestSolveTime) ? activeGameResponseBody[0].currentTime : dailyStatsResponseBody[0].fastestSolveTime,
+            "fastestSolveTime": (activeGameResponseBody[0].currentTime > dailyStatsResponseBody[0].fastestSolveTime && dailyStatsResponseBody[0].fastestSolveTime != 0)
+                ? dailyStatsResponseBody[0].fastestSolveTime : activeGameResponseBody[0].currentTime,
             "totalSolveTime": activeGameResponseBody[0].currentTime + dailyStatsResponseBody[0].totalSolveTime,
             "numHintsUsed": activeGameResponseBody[0].numHintsUsed + dailyStatsResponseBody[0].numHintsUsed,
             "numWrongCellsPlayed": activeGameResponseBody[0].numWrongCellsPlayed + dailyStatsResponseBody[0].numWrongCellsPlayed,


### PR DESCRIPTION
Changelog: 
- Since fastestGame initializes to 0, we need to ignore zero values when determining when to replace active game